### PR TITLE
Fix username!=email

### DIFF
--- a/indicia_api.module
+++ b/indicia_api.module
@@ -229,6 +229,11 @@ function indicia_api_authorise_user() {
   else {
     // Name.
     $existing_user = user_load_by_name($name);
+
+    // In case the username is an email and username != email
+    if (empty($existing_user)) {
+      $existing_user = user_load_by_mail($name);
+    }
   }
 
   if (empty($existing_user)) {
@@ -474,6 +479,12 @@ function ownAuthenticated($user, $silent = FALSE) {
     if (filter_var($_SERVER['PHP_AUTH_USER'], FILTER_VALIDATE_EMAIL)) {
       // Email.
       if (strtolower($_SERVER['PHP_AUTH_USER']) === strtolower($user->mail->value())) {
+        $own = TRUE;
+      }
+      // In case the username is an email and username != email
+      elseif (strtolower($_SERVER['PHP_AUTH_USER']) === strtolower($user->name->value())) {
+        // Name.
+        indicia_api_log('Email was found matching the username.');
         $own = TRUE;
       }
       if (!$silent) {

--- a/indicia_api.module
+++ b/indicia_api.module
@@ -225,15 +225,15 @@ function indicia_api_authorise_user() {
   if(filter_var($_SERVER['PHP_AUTH_USER'], FILTER_VALIDATE_EMAIL)) {
     // Email.
     $existing_user = user_load_by_mail($name);
+    
+    // In case the username is an email and username != email
+    if (empty($existing_user)) {
+      $existing_user = user_load_by_name($name);
+    }
   }
   else {
     // Name.
     $existing_user = user_load_by_name($name);
-
-    // In case the username is an email and username != email
-    if (empty($existing_user)) {
-      $existing_user = user_load_by_mail($name);
-    }
   }
 
   if (empty($existing_user)) {

--- a/v1/users/user/entry.inc
+++ b/v1/users/user/entry.inc
@@ -61,7 +61,7 @@ function load_user($uid) {
 
     // In case the username is an email and username != email
     if (empty($user)) {
-      indicia_api_log('Loading user by uid: ' . $uid . '.');
+      indicia_api_log('Loading user by name: ' . $uid . '.');
       $user = user_load_by_name($uid);
     }
   }

--- a/v1/users/user/entry.inc
+++ b/v1/users/user/entry.inc
@@ -61,6 +61,7 @@ function load_user($uid) {
 
     // In case the username is an email and username != email
     if (empty($user)) {
+      indicia_api_log('Loading user by uid: ' . $uid . '.');
       $user = user_load_by_name($uid);
     }
   }

--- a/v1/users/user/entry.inc
+++ b/v1/users/user/entry.inc
@@ -58,6 +58,11 @@ function load_user($uid) {
   elseif (filter_var($uid, FILTER_VALIDATE_EMAIL)) {
     indicia_api_log('Loading user by email: ' . $uid . '.');
     $user = user_load_by_mail($uid);
+
+    // In case the username is an email and username != email
+    if (empty($user)) {
+      $user = user_load_by_name($uid);
+    }
   }
   // Name.
   else {


### PR DESCRIPTION
There is an issue where the person's username is an email but the user's email is different from the username, so that the Indicia API thinks the user is logging in by an email which it cannot find. To illustrate this convoluted scenario:

This is **OK**:
name: Tom Jones
user: tom_jones
email: tom@jones.com

This is **OK**:
name: Tom Jones
user: tom@jones.com
email: tom@jones.com

This is **NOT OK**:
name: Tom Jones
user: tom_other_email@jones.com
email: tom@jones.com

